### PR TITLE
Fixed typo

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -43,7 +43,7 @@
     },
     "Christi Himmelfahrt": {
       date: 'easter+39',
-      kaywords: ['ascension']
+      keywords: ['ascension']
     },
     "Pfingstsonntag": {
       date: 'easter+49',

--- a/locale/dk.js
+++ b/locale/dk.js
@@ -28,7 +28,7 @@
     },
     "Kristi himmelfartsdag": {
       date: 'easter+39',
-      kaywords: ['ascension']
+      keywords: ['ascension']
     },
     "Pinsedag": {
       date: 'easter+49',


### PR DESCRIPTION
A typo would prevent "Kristi himmelfartsdag" from having keyword or being found via keyword